### PR TITLE
Tolerate partial API discovery

### DIFF
--- a/pkg/autoscaler/k8sclient/k8sclient_test.go
+++ b/pkg/autoscaler/k8sclient/k8sclient_test.go
@@ -62,6 +62,19 @@ func TestDiscoverAPI(t *testing.T) {
 				{Name: "replicasets", Namespaced: true, Kind: "ReplicaSet"},
 			},
 		}
+
+		groups := metav1.APIGroupList{
+			Groups: []metav1.APIGroup{
+				{
+					Name: "custom.group.example.com",
+					Versions: []metav1.GroupVersionForDiscovery{
+						{GroupVersion: "custom.group.example.com/v1alpha1", Version: "v1alpha1"},
+					},
+					PreferredVersion: metav1.GroupVersionForDiscovery{GroupVersion: "custom.group.example.com/v1alpha1", Version: "v1alpha1"},
+				},
+			},
+		}
+
 		switch req.URL.Path {
 		case "/api":
 			obj = &metav1.APIVersions{
@@ -71,10 +84,16 @@ func TestDiscoverAPI(t *testing.T) {
 			}
 		case "/api/v1":
 			obj = &stable
+		case "/apis":
+			obj = &groups
+		case "/apis/custom.group.example.com/v1alpha1":
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
 		default:
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}
+
 		output, err := json.Marshal(obj)
 		if err != nil {
 			t.Fatalf("unexpected encoding error: %v", err)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The API discovery is now tolerating a partial discovery failure, e.g. caused due to unavailable API groups.

**Which issue(s) this PR fixes**:
Fixes #35

**Special notes for your reviewer**:
I added a unit test that simulates the behaviour and tested it successfully in a real-world scenario. If you like you can use `rfranzke/cpvpa-amd64:v0.8.2-1-g5754e13` Docker image for testing.

**Does this PR introduce a user-facing change?**:
```release-note
The `cluster-proportional-vertical-autoscaler` is no longer crashing if it cannot fully discover the API. Instead, it tolerates a partial discovery as long as its relevant API groups are discoverable.
```