### PR TITLE
Remove inactive members from OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,6 +3,7 @@
 
 approvers:
   - thockin
-  - dnardo
   - MrHohn
   - bowei
+emeritus_approvers:
+- dnardo


### PR DESCRIPTION
For kubernetes/org#2013

As a part of cleaning up inactive members (who haven't been active since
the release of v1.11) from OWNERS, this commit removes dnardo from
the OWNERS file.

/assign @MrHohn 
cc @mrbobbytables @dnardo 