### PR TITLE
Change the configuration from a map to a list

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,23 +80,28 @@ The configuration should be in JSON format and supports the following parameters
       
 Example:
 
-```
-"containerA": {
-  "requests": {
-    "cpu": {
-      "base": "10m", "step":"1m", "coresPerStep":1
-    },
-    "memory": {
-      "base": "8Mi", "step":"1Mi", "coresPerStep":1
+```json
+[
+  {
+    "name": "containerA",
+    "requests": {
+      "cpu": {
+        "base": "10m", "step": "1m", "coresPerStep": 1
+      },
+      "memory": {
+        "base": "8Mi", "step": "1Mi", "coresPerStep": 1
+      }
+    }
+  },
+  {
+    "name": "containerB",
+    "requests": {
+      "cpu": {
+        "base": "250m", "step": "100m", "coresPerStep": 10
+      }
     }
   }
-"containerB": {
-  "requests": {
-    "cpu": {
-      "base": "250m", "step":"100m", "coresPerStep":10
-    },
-  }
-}
+]
 ```
 
 ## Running the cluster-proportional-vertical-autoscaler
@@ -171,7 +176,17 @@ spec:
           - --namespace=kube-system
           - --logtostderr=true
           - --poll-period-seconds=10
-          - --default-config={"thing":{"requests":{"cpu":{"base":"250m","step":"100m","nodesPerStep":10}}}}
+          - |
+            --default-config=[
+              {
+                "name": "thing",
+                "requests": {
+                  "cpu": {
+                    "base": "250m", "step": "100m", "nodesPerStep": 10
+                  }
+                }
+              }
+            ]
       tolerations:
       - key: "CriticalAddonsOnly"
         operator: "Exists"

--- a/examples/cpvpa-nginx-example-with-configmap.yaml
+++ b/examples/cpvpa-nginx-example-with-configmap.yaml
@@ -19,8 +19,9 @@ metadata:
   namespace: default
 data:
   nginx-autoscaler: |-
-    {
-      "nginx-vertical-autoscale-example": {
+    [
+      {
+        "name": "nginx-vertical-autoscale-example",
         "requests": {
           "cpu": {
             "base": "100m",
@@ -29,7 +30,7 @@ data:
           }
         }
       }
-    }
+    ]
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/examples/cpvpa-nginx-example.yaml
+++ b/examples/cpvpa-nginx-example.yaml
@@ -60,6 +60,18 @@ spec:
             - --logtostderr=true
             - --poll-period-seconds=10
             - --v=2
-            - --default-config={"nginx-vertical-autoscale-example":{"requests":{"cpu":{"base":"100m","step":"100m","nodesPerStep":1}}}}
+            - |
+              --default-config=[
+                {
+                  "name": "nginx-vertical-autoscale-example",
+                  "requests": {
+                    "cpu": {
+                      "base": "100m",
+                      "step": "100m",
+                      "nodesPerStep": 1
+                    }
+                  }
+                }
+              ]
       # Uncomment below line if you are using RBAC configs under the RBAC folder.              
       # serviceAccountName: cluster-proportional-vertical-autoscaler-example

--- a/pkg/autoscaler/autoscaler_test.go
+++ b/pkg/autoscaler/autoscaler_test.go
@@ -68,6 +68,27 @@ func TestRun(t *testing.T) {
 	defer close(autoScaler.stopCh)
 }
 
+func TestParseLegacyConfig(t *testing.T) {
+	var legacyConfig = `
+{
+  "fake-agent": {
+    "requests": {
+      "cpu": {
+        "base": "10m", "step":"1m", "coresPerStep": 1
+      }
+    }
+  }
+}
+`
+	cfg, err := parseLegacyConfig([]byte(legacyConfig))
+	if err != nil {
+		t.Fatalf("invalid default config: %v", err)
+	}
+	if cfg[0].Name != "fake-agent" {
+		t.Errorf("expected %s got %s", "fake-agent", cfg[0].Name)
+	}
+}
+
 func TestCalculatePerCores(t *testing.T) {
 	var coresPerStep = `
 [

--- a/pkg/autoscaler/autoscaler_test.go
+++ b/pkg/autoscaler/autoscaler_test.go
@@ -29,8 +29,9 @@ import (
 
 func TestRun(t *testing.T) {
 	var asConfig = `
-{
-  "fake-agent": {
+[
+  {
+    "name": "fake-agent",
     "requests": {
       "cpu": {
         "base": "10m", "step":"1m", "coresPerStep":1
@@ -40,7 +41,7 @@ func TestRun(t *testing.T) {
       }
     }
   }
-}
+]
 `
 	mockK8s := k8sclient.MockK8sClient{
 		NumOfNodes: 4,
@@ -69,15 +70,16 @@ func TestRun(t *testing.T) {
 
 func TestCalculatePerCores(t *testing.T) {
 	var coresPerStep = `
-{
-  "fake-agent": {
+[
+  {
+    "name": "fake-agent",
     "requests": {
       "cpu": {
         "base": "%dm", "step":"%dm", "coresPerStep":%d
       }
     }
   }
-}
+]
 `
 	for _, tt := range []struct {
 		name     string
@@ -157,7 +159,7 @@ func TestCalculatePerCores(t *testing.T) {
 		if err != nil {
 			t.Errorf("failed to get cluster size")
 		}
-		val := calculate(cfg["fake-agent"].Requests["cpu"], sz)
+		val := calculate(cfg[0].Requests["cpu"], sz)
 		if val != tt.expVal {
 			t.Errorf("expected %d got %d", tt.expVal, val)
 		}
@@ -166,15 +168,16 @@ func TestCalculatePerCores(t *testing.T) {
 
 func TestCalculatePerNodes(t *testing.T) {
 	var nodesPerStep = `
-{
-  "fake-agent": {
+[
+  {
+    "name": "fake-agent",
     "requests": {
       "cpu": {
         "base": "%dm", "step":"%dm", "nodesPerStep":%d
       }
     }
   }
-}
+]
 `
 	for _, tt := range []struct {
 		name     string
@@ -254,7 +257,7 @@ func TestCalculatePerNodes(t *testing.T) {
 		if err != nil {
 			t.Errorf("failed to get cluster size")
 		}
-		val := calculate(cfg["fake-agent"].Requests["cpu"], sz)
+		val := calculate(cfg[0].Requests["cpu"], sz)
 		if val != tt.expVal {
 			t.Errorf("expected %d got %d", tt.expVal, val)
 		}

--- a/pkg/autoscaler/k8sclient/k8sclient.go
+++ b/pkg/autoscaler/k8sclient/k8sclient.go
@@ -41,7 +41,7 @@ type K8sClient interface {
 	// GetClusterSize counts schedulable nodes and cores in the cluster
 	GetClusterSize() (*ClusterSize, error)
 	// UpdateResources updates the resource needs for the containers in the target
-	UpdateResources(resources map[string]apiv1.ResourceRequirements) error
+	UpdateResources(resources []apiv1.Container) error
 }
 
 // k8sClient - Wraps all Kubernetes API client functionality.
@@ -325,14 +325,7 @@ func (k *k8sClient) GetClusterSize() (clusterStatus *ClusterSize, err error) {
 	return clusterStatus, nil
 }
 
-func (k *k8sClient) UpdateResources(resources map[string]apiv1.ResourceRequirements) error {
-	ctrs := []interface{}{}
-	for ctrName, res := range resources {
-		ctrs = append(ctrs, map[string]interface{}{
-			"name":      ctrName,
-			"resources": res,
-		})
-	}
+func (k *k8sClient) UpdateResources(containers []apiv1.Container) error {
 	patch := map[string]interface{}{
 		"apiVersion": fmt.Sprintf("%s", k.target.GroupVersion),
 		"kind":       k.target.Kind,
@@ -342,7 +335,7 @@ func (k *k8sClient) UpdateResources(resources map[string]apiv1.ResourceRequireme
 		"spec": map[string]interface{}{
 			"template": map[string]interface{}{
 				"spec": map[string]interface{}{
-					"containers": ctrs,
+					"containers": containers,
 				},
 			},
 		},

--- a/pkg/autoscaler/k8sclient/k8sclient_test.go
+++ b/pkg/autoscaler/k8sclient/k8sclient_test.go
@@ -203,15 +203,18 @@ func TestUpdateResources(t *testing.T) {
 			target:    target,
 		}
 
-		newReqs := map[string]apiv1.ResourceRequirements{}
-		newReqs["thing"] = apiv1.ResourceRequirements{
-			Requests: map[apiv1.ResourceName]resource.Quantity{},
-			Limits:   map[apiv1.ResourceName]resource.Quantity{},
-		}
+		newCtrs := []apiv1.Container{}
+		newCtrs = append(newCtrs, apiv1.Container{
+			Name: "things",
+			Resources: apiv1.ResourceRequirements{
+				Requests: map[apiv1.ResourceName]resource.Quantity{},
+				Limits:   map[apiv1.ResourceName]resource.Quantity{},
+			},
+		})
 		r := resource.NewQuantity(0, resource.BinarySI)
 		r.SetMilli(10)
-		newReqs["thing"].Requests[apiv1.ResourceName("cpu")] = *r
-		if err := k8scli.UpdateResources(newReqs); err != nil {
+		newCtrs[0].Resources.Requests[apiv1.ResourceName("cpu")] = *r
+		if err := k8scli.UpdateResources(newCtrs); err != nil {
 			t.Errorf("failed to update resources for target %q: %v", tc.target, err)
 		}
 	}

--- a/pkg/autoscaler/k8sclient/testing/mock_k8sclient.go
+++ b/pkg/autoscaler/k8sclient/testing/mock_k8sclient.go
@@ -35,6 +35,6 @@ func (k *MockK8sClient) GetClusterSize() (*k8sclient.ClusterSize, error) {
 }
 
 // UpdateResources mocks updating resources needs for containers in the target
-func (k *MockK8sClient) UpdateResources(resources map[string]apiv1.ResourceRequirements) error {
+func (k *MockK8sClient) UpdateResources(containers []apiv1.Container) error {
 	return nil
 }


### PR DESCRIPTION
This closes #43 by implementing solution 4 described in the issue. Since containers are in a list in Kubernetes, it feels more natural to have a list as a configuration.

It is a breaking change, considering CPVPA is not marked as stable, it may be acceptable.

I have been able to test it in a cluster, all works well.

### Release notes

~~~
New image is available on: k8s.gcr.io/cpvpa-amd64:v0.9.0

BREAKING CHANGES:

- Change the configuration from a map to a list ([#44](https://github.com/kubernetes-sigs/cluster-proportional-vertical-autoscaler/pull/44))

  Before:

  ```json
  {
    "thing": {
      "requests": {
        "cpu": {
          "base": "250m",
          "step": "100m",
          "nodesPerStep": 10
        }
      }
    }
  }
  ```

  After:

  ```json
  [
    {
      "name": "thing",
      "requests": {
        "cpu": {
          "base": "250m",
          "step": "100m",
          "nodesPerStep": 10
        }
      }
    }
  ]
  ```
~~~
