### PR TITLE
Fixed comparison of maximum caliculation

### DIFF
--- a/pkg/autoscaler/autoscaler_server.go
+++ b/pkg/autoscaler/autoscaler_server.go
@@ -209,7 +209,7 @@ func calculate(cfg ResourceScaleConfig, cluster *k8sclient.ClusterSize) int64 {
 		npi = *cfg.NodesPerStep
 	}
 	wantByCores := base + (step * int64(increments(cluster.Cores, cpi)))
-	if max < 0 && wantByCores > max {
+	if max > 0 && wantByCores > max {
 		wantByCores = max
 	}
 	wantByNodes := base + (step * int64(increments(cluster.Nodes, npi)))


### PR DESCRIPTION
The comparison for checking that the `wantByCores` is bounded by the allowed maximum seems to have the incorrect comparison operator. The check for `wantByNodes` four lines below seems correct.