### PR TITLE
Switch Example Image References to registry.k8s.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ spec:
     spec:
       containers:
       - name: autoscaler
-        image: k8s.gcr.io/cpvpa-amd64:v0.8.1
+        image: registry.k8s.io/cpvpa-amd64:v0.8.1
         resources:
           requests:
             cpu: "20m"

--- a/examples/cpvpa-nginx-example-with-configmap.yaml
+++ b/examples/cpvpa-nginx-example-with-configmap.yaml
@@ -70,7 +70,7 @@ spec:
         app: autoscaler
     spec:
       containers:
-        - image: k8s.gcr.io/cpvpa-amd64:{LATEST_RELEASE}
+        - image: registry.k8s.io/cpvpa-amd64:{LATEST_RELEASE}
           name: autoscaler
           command:
             - /cpvpa

--- a/examples/cpvpa-nginx-example.yaml
+++ b/examples/cpvpa-nginx-example.yaml
@@ -51,7 +51,7 @@ spec:
         app: autoscaler
     spec:
       containers:
-        - image: k8s.gcr.io/cpvpa-amd64:{LATEST_RELEASE}
+        - image: registry.k8s.io/cpvpa-amd64:{LATEST_RELEASE}
           name: autoscaler
           command:
             - /cpvpa


### PR DESCRIPTION
As per https://github.com/kubernetes/k8s.io/issues/4738, updating the registry referred to in examples to `registry.k8s.io`